### PR TITLE
VER3-390 remove python 3.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/pyglimmpse/multirep.py
+++ b/pyglimmpse/multirep.py
@@ -556,7 +556,7 @@ def _trace(eval_HINVE, rank_X, total_N):
 
 def _calc_omega(min_rank_C_U: float, eval_HINVE: [], rank_X: float, total_N: float) -> float:
     """calculate the noncentrality parameter, omega"""
-    hlt = _trace(eval_HINVE, rank_X, total_N)
+    hlt = _trace(np.sum(eval_HINVE), rank_X, total_N)
     omega = (total_N * min_rank_C_U) * (hlt / min_rank_C_U)
     return omega
 
@@ -620,7 +620,7 @@ def _pbt_two_moment_df1_df2(rank_C, rank_U, rank_X, total_N):
 
 def _pbt_population_value(evalt, min_rank_C_U):
     """ calculate the populations value for a pbt"""
-    v = sum(evalt / (np.ones((min_rank_C_U, 1)) + evalt))
+    v = np.sum(evalt / (np.ones((min_rank_C_U, 1)) + evalt))
     return v
 
 


### PR DESCRIPTION
remove python 3.3 from travis config as enum is not supported till python 3.4.